### PR TITLE
Use default.target

### DIFF
--- a/udiskie.service
+++ b/udiskie.service
@@ -4,8 +4,8 @@ Description=Handle automounting of usb devices
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/udiskie
+ExecStart=/usr/bin/udiskie --smart-tray
 
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
I don't know about you, but `multi-user.target` has never worked to start this service at boot. What has worked for me is to use `default.target`.

```
systemctl --user --type=target
systemctl --global --type=target
```

Also added smart-tray option because no use of having icon occupy space when nothing is plugged in.